### PR TITLE
Added quickfix for Homebrew and other locally installed versions

### DIFF
--- a/OpenMesher/tunnelobjects/__init__.py
+++ b/OpenMesher/tunnelobjects/__init__.py
@@ -46,7 +46,7 @@ class Link():
     
     def __init__(self, serverrouter, clientrouter, linkport, iface_number, block):
         #BUG: Hack because Ubuntu 11.10 moved openvpn from /bin to /sbin and the user doesn't have a path to /sbin.  Need to search path, then check /sbin
-        for ovp in ['/bin', '/sbin', '/usr/bin', '/usr/sbin']:
+        for ovp in ['/bin', '/sbin', '/usr/bin', '/usr/sbin', '/usr/local/bin', '/usr/local/sbin']:
             if os.path.isfile('%s/openvpn' %ovp):
                 self.OpenVPNPath = "%s/openvpn" %(ovp)
                 break


### PR DESCRIPTION
This is a 2-minute patch that's workable, but if you want to make this code more resilient, you may consider searching using the PATH variable or using the `which` command to find it for you.

For example, if I'd used MacPorts to install OpenVPN instead of Homebrew, it would have been located in /opt/local/bin or /opt/local/sbin